### PR TITLE
chore: update link

### DIFF
--- a/docs/01-prerequisites.md
+++ b/docs/01-prerequisites.md
@@ -12,7 +12,7 @@ This tutorial leverages the [Google Cloud Platform](https://cloud.google.com/) t
 
 ### Install the Google Cloud SDK
 
-Follow the Google Cloud SDK [documentation](https://cloud.google.com/sdk/) to install and configure the `gcloud` command line utility.
+Follow the Google Cloud SDK [documentation](https://cloud.google.com/sdk/docs/install) to install and configure the `gcloud` command line utility.
 
 Verify the Google Cloud SDK version is 338.0.0 or higher:
 


### PR DESCRIPTION
updates the install link to the latest docs page, as the old one required clicking around for a while to find the correct stuff